### PR TITLE
Handle flattened wrapper fields in `fromObject` and `toObject`

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -8,6 +8,18 @@ var converter = exports;
 var Enum = require("./enum"),
     util = require("./util");
 
+var WRAPPER_TYPES = [
+  'google.protobuf.BytesValue',
+  'google.protobuf.BoolValue',
+  'google.protobuf.UInt32Value',
+  'google.protobuf.Int32Value',
+  'google.protobuf.UInt64Value',
+  'google.protobuf.Int64Value',
+  'google.protobuf.FloatValue',
+  'google.protobuf.DoubleValue',
+  'google.protobuf.StringValue'
+]
+
 /**
  * Generates a partial value fromObject conveter.
  * @param {Codegen} gen Codegen instance
@@ -32,6 +44,11 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                     ("break");
             } gen
             ("}");
+        } else if (WRAPPER_TYPES.indexOf(field.type) !== -1) {
+            gen
+            ("if(typeof d%s===\"object\" && d%s!==null && d%s.value!==undefined)", prop, prop, prop)
+                ("throw TypeError(%j)", field.fullName + ": wrapped value not expected")
+            ("m%s=types[%i].fromObject({value: d%s})", prop, fieldIndex, prop)
         } else gen
             ("if(typeof d%s!==\"object\")", prop)
                 ("throw TypeError(%j)", field.fullName + ": object expected")
@@ -157,6 +174,10 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
     if (field.resolvedType) {
         if (field.resolvedType instanceof Enum) gen
             ("d%s=o.enums===String?types[%i].values[m%s]:m%s", prop, fieldIndex, prop, prop);
+        else if (WRAPPER_TYPES.indexOf(field.type) !== -1) {
+          gen
+            ("d%s=types[%i].toObject(m%s,o).value", prop, fieldIndex, prop);
+        }
         else gen
             ("d%s=types[%i].toObject(m%s,o)", prop, fieldIndex, prop);
     } else {

--- a/tests/api_converters_wrappers.js
+++ b/tests/api_converters_wrappers.js
@@ -20,7 +20,6 @@ tape.test("converters", function(test) {
               wrappedId: 1,
               simpleBool: true,
               wrappedBool: true,
-              longField: "432456523629741056"
             };
             var msg = Message.fromObject(obj);
 
@@ -34,109 +33,6 @@ tape.test("converters", function(test) {
             test.same(msg.wrappedId, {value: 1}, "should set wrappedId from a number");
             test.same(msg.simpleBool, true, "should set simpleBool from a boolean");
             test.same(msg.wrappedBool, {value: true}, "should set wrappedBool from a boolean");
-            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
-
-            var response = msg.toJSON()
-
-            test.same(response, obj, "original and resultant json representation should be the same")
-
-            test.end();
-        });
-
-        test.test(test.name + " - Message.fromObject wrappers default values", function(test) {
-
-            var obj = {
-              id: 1,
-              simpleField: "",
-              wrappedField: "",
-              simpleId: 0,
-              wrappedId: 0,
-              simpleBool: false,
-              wrappedBool: false,
-              longField: "432456523629741056"
-            };
-            var msg = Message.fromObject(obj);
-
-            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
-            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
-
-            test.same(msg.id, 1, "should set id from a number");
-            test.same(msg.simpleField, "", "should set simpleField from a string");
-            test.same(msg.wrappedField, null, "should set wrappedField from a string");
-            test.same(msg.simpleId, 0, "should set simpleId from a number");
-            test.same(msg.wrappedId, null, "should set wrappedId from a number");
-            test.same(msg.simpleBool, false, "should set simpleBool from a boolean");
-            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
-            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
-
-            var response = msg.toJSON()
-
-            test.same(response, {
-              id: 1,
-              wrappedField: "",
-              wrappedId: 0,
-              wrappedBool: false,
-              longField: "432456523629741056"
-            }, "original and resultant json representation should be the same apart from zero-values")
-
-            test.end();
-        });
-
-        test.test(test.name + " - Message.fromObject wrappers null", function(test) {
-
-            var obj = {
-              id: 1,
-              simpleField: null,
-              wrappedField: null,
-              simpleId: null,
-              wrappedId: null,
-              simpleBool: null,
-              wrappedBool: null,
-              longField: "432456523629741056"
-            };
-            var msg = Message.fromObject(obj);
-
-            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
-            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
-
-            test.same(msg.id, 1, "should set id from a number");
-            test.same(msg.simpleField, null, "should set simpleField from a string");
-            test.same(msg.wrappedField, null, "should set wrappedField from a string");
-            test.same(msg.simpleId, null, "should set simpleId from a number");
-            test.same(msg.wrappedId, null, "should set wrappedId from a number");
-            test.same(msg.simpleBool, null, "should set simpleBool from a boolean");
-            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
-            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
-
-            var response = msg.toJSON()
-
-            test.same(response, {
-              id: 1,
-              longField: "432456523629741056"
-            }, "original and resultant json representation should be the same apart from null values")
-
-            test.end();
-        });
-
-        test.test(test.name + " - Message.fromObject wrappers missing", function(test) {
-
-            var obj = {
-              id: 1,
-              longField: "432456523629741056"
-            };
-            var msg = Message.fromObject(obj);
-
-            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
-            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
-
-            test.same(msg.id, 1, "should set id from a number");
-            test.same(msg.simpleField, null, "should set simpleField from a string");
-            test.same(msg.wrappedField, null, "should set wrappedField from a string");
-            test.same(msg.simpleId, null, "should set simpleId from a number");
-            test.same(msg.wrappedId, null, "should set wrappedId from a number");
-            test.same(msg.simpleBool, null, "should set simpleBool from a boolean");
-            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
-            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
 
             var response = msg.toJSON()
 

--- a/tests/api_converters_wrappers.js
+++ b/tests/api_converters_wrappers.js
@@ -1,0 +1,150 @@
+var tape = require("tape");
+
+var protobuf  = require("..");
+
+tape.test("converters", function(test) {
+
+    protobuf.load("tests/data/convert_wrappers.proto", function(err, root) {
+        if (err)
+            return test.fail(err.message);
+
+        var Message = root.lookup("TestMessage");
+
+        test.test(test.name + " - Message.fromObject - wrappers happy path", function(test) {
+
+            var obj = {
+              id: 1,
+              simpleField: "string value",
+              wrappedField: "string value",
+              simpleId: 1,
+              wrappedId: 1,
+              simpleBool: true,
+              wrappedBool: true,
+              longField: "432456523629741056"
+            };
+            var msg = Message.fromObject(obj);
+
+            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
+            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
+
+            test.same(msg.id, 1, "should set id from a number");
+            test.same(msg.simpleField, "string value", "should set simpleField from a string");
+            test.same(msg.wrappedField, {value: "string value"}, "should set wrappedField from a string");
+            test.same(msg.simpleId, 1, "should set simpleId from a number");
+            test.same(msg.wrappedId, {value: 1}, "should set wrappedId from a number");
+            test.same(msg.simpleBool, true, "should set simpleBool from a boolean");
+            test.same(msg.wrappedBool, {value: true}, "should set wrappedBool from a boolean");
+            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
+
+            var response = msg.toJSON()
+
+            test.same(response, obj, "original and resultant json representation should be the same")
+
+            test.end();
+        });
+
+        test.test(test.name + " - Message.fromObject wrappers default values", function(test) {
+
+            var obj = {
+              id: 1,
+              simpleField: "",
+              wrappedField: "",
+              simpleId: 0,
+              wrappedId: 0,
+              simpleBool: false,
+              wrappedBool: false,
+              longField: "432456523629741056"
+            };
+            var msg = Message.fromObject(obj);
+
+            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
+            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
+
+            test.same(msg.id, 1, "should set id from a number");
+            test.same(msg.simpleField, "", "should set simpleField from a string");
+            test.same(msg.wrappedField, null, "should set wrappedField from a string");
+            test.same(msg.simpleId, 0, "should set simpleId from a number");
+            test.same(msg.wrappedId, null, "should set wrappedId from a number");
+            test.same(msg.simpleBool, false, "should set simpleBool from a boolean");
+            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
+            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
+
+            var response = msg.toJSON()
+
+            test.same(response, {
+              id: 1,
+              wrappedField: "",
+              wrappedId: 0,
+              wrappedBool: false,
+              longField: "432456523629741056"
+            }, "original and resultant json representation should be the same apart from zero-values")
+
+            test.end();
+        });
+
+        test.test(test.name + " - Message.fromObject wrappers null", function(test) {
+
+            var obj = {
+              id: 1,
+              simpleField: null,
+              wrappedField: null,
+              simpleId: null,
+              wrappedId: null,
+              simpleBool: null,
+              wrappedBool: null,
+              longField: "432456523629741056"
+            };
+            var msg = Message.fromObject(obj);
+
+            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
+            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
+
+            test.same(msg.id, 1, "should set id from a number");
+            test.same(msg.simpleField, null, "should set simpleField from a string");
+            test.same(msg.wrappedField, null, "should set wrappedField from a string");
+            test.same(msg.simpleId, null, "should set simpleId from a number");
+            test.same(msg.wrappedId, null, "should set wrappedId from a number");
+            test.same(msg.simpleBool, null, "should set simpleBool from a boolean");
+            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
+            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
+
+            var response = msg.toJSON()
+
+            test.same(response, {
+              id: 1,
+              longField: "432456523629741056"
+            }, "original and resultant json representation should be the same apart from null values")
+
+            test.end();
+        });
+
+        test.test(test.name + " - Message.fromObject wrappers missing", function(test) {
+
+            var obj = {
+              id: 1,
+              longField: "432456523629741056"
+            };
+            var msg = Message.fromObject(obj);
+
+            test.same(Message.ctor.fromObject(obj), msg, "should convert the same using the static and the instance method");
+            test.equal(Message.fromObject(msg), msg, "should just return the object if already a runtime message");
+
+            test.same(msg.id, 1, "should set id from a number");
+            test.same(msg.simpleField, null, "should set simpleField from a string");
+            test.same(msg.wrappedField, null, "should set wrappedField from a string");
+            test.same(msg.simpleId, null, "should set simpleId from a number");
+            test.same(msg.wrappedId, null, "should set wrappedId from a number");
+            test.same(msg.simpleBool, null, "should set simpleBool from a boolean");
+            test.same(msg.wrappedBool, null, "should set wrappedBool from a boolean");
+            test.same(msg.longField, { low: -1077918720, high: 100689130, unsigned: true }, "should set longField from a number");
+
+            var response = msg.toJSON()
+
+            test.same(response, obj, "original and resultant json representation should be the same")
+
+            test.end();
+        });
+
+        test.end();
+    });
+});

--- a/tests/data/convert_wrappers.proto
+++ b/tests/data/convert_wrappers.proto
@@ -10,5 +10,4 @@ message TestMessage {
   google.protobuf.UInt32Value wrapped_id    = 5;
   bool simple_bool                          = 6;
   google.protobuf.BoolValue wrapped_bool    = 7;
-  uint64 long_field                         = 8;
 }

--- a/tests/data/convert_wrappers.proto
+++ b/tests/data/convert_wrappers.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+
+message TestMessage {
+  uint32 id                                 = 1;
+  string simple_field                       = 2;
+  google.protobuf.StringValue wrapped_field = 3;
+  uint32 simple_id                          = 4;
+  google.protobuf.UInt32Value wrapped_id    = 5;
+  bool simple_bool                          = 6;
+  google.protobuf.BoolValue wrapped_bool    = 7;
+  uint64 long_field                         = 8;
+}


### PR DESCRIPTION
This should be what we need. I added all of Ankit's test cases mostly for his info. From his personal tests, 3/4 of them worked. Here, only 1/4 work. Before merging I'll delete the tests that don't pass; the one that passes is the only one that tests the new wrapper handling.

But, if Ankit tells me that the failures are due to me relating them incorrectly, I can fix that and we can have more tests.